### PR TITLE
Disable pointer-events in visualizer, so we can still use the controls behind it

### DIFF
--- a/emoticons/style.css
+++ b/emoticons/style.css
@@ -69,4 +69,5 @@ canvas {
   position: fixed;
   bottom: 0;
   left: 0;
+  pointer-events: none;
 }


### PR DESCRIPTION
As the visualizer ends up over the emoticons, without this patch, they're unusable when the visualizer is enabled.

I'm sending this to your master, but I'm not sure if sending to gh-pages would be better. Unless you'd like to have the ability to push stuff without it getting into "production", I would suggest deleting master and setting gh-pages as the default branch. It's quite easy to do in the repository's settings.

BTW, congrats on the idea. It's a very cool hack :smile: 
