### PR TITLE
trigger callbacks only if they are defined

### DIFF
--- a/lib/sonic-server.js
+++ b/lib/sonic-server.js
@@ -78,7 +78,9 @@ SonicServer.prototype.setDebug = function(value) {
 };
 
 SonicServer.prototype.fire_ = function(callback, arg) {
-  callback(arg);
+  if (typeof(callback) === 'function') {
+    callback(arg);
+  }
 };
 
 SonicServer.prototype.onStream_ = function(stream) {


### PR DESCRIPTION
Check if the callback is defined as a function before attempting to trigger it. 

This oversight became evident after my previous PR for `SonicServer.on('character', cb)`, but it also affected the original `SonicServer.on('message', cb)`.

Aside: `lib/api-test.html` does not work because the browserified build in `lib/sonicnet.js` does not export to global `window` namespace. 

In [lib/main.js](lib/main.js), may I change `module.exports {...}` to `window.SonicServer = SonicServer` and so forth? I have the change in [another PR](https://github.com/oslego/sonicnet.js/commit/fd09893368ea3fd0cf09bf3a18419e7c9debac9b) and it seems to fix the broken test file (and makes life easier working with the standalone sonicnet lib)