### PR TITLE
standalone lib for use with vanilla js in the browser

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,2 +1,2 @@
 default:
-	browserify main.js -o build/sonicnet.js
+	browserify main.js --standalone Sonicnet > build/sonicnet.js

--- a/lib/api-test.html
+++ b/lib/api-test.html
@@ -2,7 +2,6 @@
 
 <script src="build/sonicnet.js"></script>
 <script>
-var audioContext = new webkitAudioContext();
 var ALPHABET = '0123456789';
 var MESSAGE = '314159';
 
@@ -10,15 +9,15 @@ var button = document.querySelector('#message');
 button.addEventListener('click', onButton);
 
 function onButton() {
-  ssocket = new SonicSocket({alphabet: ALPHABET, charDuration: 0.2});
-  ssocket.send(MESSAGE);
+  socket = new Sonicnet.SonicSocket({alphabet: ALPHABET, charDuration: 0.2});
+  socket.send(MESSAGE);
 }
 
 // On some other machine:
-sserver = new SonicServer({alphabet: ALPHABET});
-sserver.on('message', function(message) {
+server = new Sonicnet.SonicServer({alphabet: ALPHABET});
+server.on('message', function(message) {
   // message is '31415'. Do something with it.
   console.log(message);
 });
-sserver.start();
+server.start();
 </script>

--- a/lib/build/sonicnet.js
+++ b/lib/build/sonicnet.js
@@ -1,4 +1,4 @@
-(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.Sonicnet = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 var SonicSocket = require('./sonic-socket.js');
 var SonicServer = require('./sonic-server.js');
 var SonicCoder = require('./sonic-coder.js');
@@ -127,11 +127,11 @@ module.exports = SonicCoder;
 var RingBuffer = require('./ring-buffer.js');
 var SonicCoder = require('./sonic-coder.js');
 
-var audioContext = window.audioContext || new webkitAudioContext();
+var audioContext = new window.AudioContext || new webkitAudioContext();
 /**
  * Extracts meaning from audio streams.
  *
- * (assumes audioContext is a WebAudioContext global variable.)
+ * (assumes audioContext is an AudioContext global variable.)
  *
  * 1. Listen to the microphone.
  * 2. Do an FFT on the input.
@@ -181,12 +181,15 @@ SonicServer.prototype.start = function() {
  */
 SonicServer.prototype.stop = function() {
   this.isRunning = false;
-  this.stream.stop();
+  this.track.stop();
 };
 
 SonicServer.prototype.on = function(event, callback) {
   if (event == 'message') {
     this.callbacks.message = callback;
+  }
+  if (event == 'character') {
+    this.callbacks.character = callback;
   }
 };
 
@@ -201,11 +204,16 @@ SonicServer.prototype.setDebug = function(value) {
 };
 
 SonicServer.prototype.fire_ = function(callback, arg) {
-  callback(arg);
+  if (typeof(callback) === 'function') {
+    callback(arg);
+  }
 };
 
 SonicServer.prototype.onStream_ = function(stream) {
-  this.stream = stream;
+  // Store MediaStreamTrack for stopping later. MediaStream.stop() is deprecated
+  // See https://developers.google.com/web/updates/2015/07/mediastream-deprecations?hl=en
+  this.track = stream.getTracks()[0];
+
   // Setup audio graph.
   var input = audioContext.createMediaStreamSource(stream);
   var analyser = audioContext.createAnalyser();
@@ -318,6 +326,7 @@ SonicServer.prototype.analysePeaks = function() {
         char != this.coder.startChar && char != this.coder.endChar) {
       this.buffer += char;
       this.lastChar = char;
+      this.fire_(this.callbacks.character, char);
     }
     // Also look for the end character to go into idle mode.
     if (char == this.coder.endChar) {
@@ -418,7 +427,7 @@ module.exports = SonicServer;
 },{"./ring-buffer.js":2,"./sonic-coder.js":3}],5:[function(require,module,exports){
 var SonicCoder = require('./sonic-coder.js');
 
-var audioContext = window.audioContext || new webkitAudioContext();
+var audioContext = new window.AudioContext || new webkitAudioContext();
 
 /**
  * Encodes text as audio streams.
@@ -477,4 +486,5 @@ SonicSocket.prototype.scheduleToneAt = function(freq, startTime, duration) {
 
 module.exports = SonicSocket;
 
-},{"./sonic-coder.js":3}]},{},[1])
+},{"./sonic-coder.js":3}]},{},[1])(1)
+});


### PR DESCRIPTION
This PR adjusts the Makefile to export the SonicServer, SonicSocket and SonicCoder under a global Sonicnet object attached to `window`. This is _in addition_ to the dependency manager hooks which browserify exposes. [See details about `--standalone` flag](http://www.forbeslindesay.co.uk/post/46324645400/standalone-browserify-builds).

This fixes `lib/api-test.html` and makes it practical to consume the library in a browser in the absence of a dependency manager. 

I [wasn't able to find a solution](http://stackoverflow.com/questions/32604311/how-to-create-standalone-browserify-bundle-exporting-directly-to-window) to configure browserify to export the individual objects directly to `window` without explicitly changing `lib/main.js` [as attempted](https://github.com/mildmojo/sonicnet.js/blob/6378c78942717bc740655ccfc7e0c4a964366e5b/lib/build/sonicnet.js#L2-L10) in @mildmojo's PR.

This changes only the build in `lib/`. The Makefiles for the demos are left unchanged. 
